### PR TITLE
fixed duplicate bookmarks problem

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -14,6 +14,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
         chrome.storage.local.get("bookmarks", function (data) {
             let bookmarks = data.bookmarks || [];
+
+            if(bookmarks.find(bookmark => bookmark.url ===url)){
+                alert("Already pinned");
+                return;
+            }
+            
             bookmarks.push({ title, url });
             chrome.storage.local.set({ bookmarks }, displayBookmarks);
         });


### PR DESCRIPTION
Enhances the PinChat Chrome extension by preventing duplicate bookmarks when saving conversations. Previously, users could save the same chat multiple times, leading to unnecessary duplicates. Now, before adding a new bookmark, the extension checks whether the URL is already stored and alerts the user if it exists.